### PR TITLE
fix: resume after browser/computer restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,7 @@
 - Adds anti-spam guards to prevent runaway tab creation
 - Added diagnostics UI
 - Updated to Angular 20 and Tailwind CSS 4
+
+## [1.3] - 2025-09-02
+
+- Fixed the continuation of rotation after browser/computer restart.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ A lightweight Chrome/Chromium extension that cycles through a list of URLs in se
     - [Local Configuration](#local-configuration)
     - [Remote Configuration (Auto-Update)](#remote-configuration-auto-update)
     - [Page Options](#page-options)
+    - [OS Autostart (Windows)](#os-autostart-windows)
   - [Configuration Examples](#configuration-examples)
     - [Local / Inline](#local--inline)
     - [Remote (host this JSON and point the extension to it)](#remote-host-this-json-and-point-the-extension-to-it)
   - [Tips \& Troubleshooting](#tips--troubleshooting)
   - [Privacy \& Permissions](#privacy--permissions)
   - [Development](#development)
+  - [Changelog](#changelog)
   - [Support](#support)
 
 ---
@@ -76,6 +78,11 @@ A small public example is here:
 | **URL**          | The page to display. `https://…` or `file://…`.                    | `url`                   | String |
 | **Display Time** | Time **in seconds** the page stays visible before switching.       | `delaySeconds`          | Number |
 | **Reload After** | Page reload interval **in seconds**. Use `0` to disable reloading. | `reloadIntervalSeconds` | Number |
+
+### OS Autostart (Windows)
+
+For automatic startup of Chrome on sign-in, follow the short guide:
+[Windows Autostart (Chrome) — Windows 10/11](windows-autostart.md).
 
 ---
 
@@ -176,6 +183,12 @@ Requirements: **Node.js ≥ 18**, **npm** and **yarn**.
    - Click **Load unpacked** and choose the **subfolder inside `dist/`** created by the build
 
 > Tip: If you change background or options code, the service worker may need a manual reload in `chrome://extensions/` during development.
+
+---
+
+## Changelog
+
+For the full change log, open this file: [Changelog](CHANGELOG.md).
 
 ---
 

--- a/description.txt
+++ b/description.txt
@@ -19,9 +19,35 @@ How to use:
 
 For local files, enable Allow access to file URLs under chrome://extensions/
 
+To start Chrome automatically after a Windows restart, follow this guide: https://github.com/skarpovru/chrome-tabs-rotator/blob/main/windows-autostart.md
+
+Open source:
+
+- Repository (README, docs): https://github.com/skarpovru/chrome-tabs-rotator
+- License: MIT
+
 Privacy:
+
 - No tracking or analytics
 - Only minimal permissions to rotate tabs and store your settings
 - Remote config is read-only; nothing is uploaded
+
+Changelog:
+
+[1.0] - 2024-08-28
+- Initial release.
+
+[1.1] - 2024-10-07
+- Immediately save imported configuration into the browser storage.
+- Added "Allow access to file URLs" activation instruction.
+
+[1.2] - 2025-08-28
+- Uses chrome.alarms for all scheduling (service-worker friendly)
+- Persists currentIndex in storage so rotation survives worker sleep/restart
+- Adds anti-spam guards to prevent runaway tab creation
+- Added diagnostics UI
+
+[1.3] - 2025-09-02
+- Fixed the continuation of rotation after browser/computer restart.
 
 Need help or want a feature? Open an issue: github.com/skarpovru/chrome-tabs-rotator/issues

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-tabs-rotator",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "scripts": {
     "prebuild": "node scripts/build-tailwind.mjs",
     "start": "ng build --watch --configuration development",

--- a/src/background/rotation.service.ts
+++ b/src/background/rotation.service.ts
@@ -81,6 +81,26 @@ export class RotationService {
       this.rotationState = state as RotationState;
       this.currentIndex = Number(state?.currentIndex ?? 0);
 
+      // If Chrome restarted, previously tracked tabs may no longer exist.
+      // Ensure we still have a complete set of tabs for the configured pages; otherwise re-initialize.
+      const { loadedConfig } = await this.loadActualConfigurationFromLocalStorage();
+      const expectedPages = loadedConfig?.pages?.length ?? 0;
+      let aliveCount = 0;
+      const tracked = Array.isArray(this.rotationState.tabIds)
+        ? [...new Set(this.rotationState.tabIds)]
+        : [];
+      for (const id of tracked) {
+        try {
+          if (id && (await this.ensureTabExists(id))) aliveCount++;
+        } catch {}
+      }
+
+      // If no tabs (or fewer than pages configured) are alive, perform a clean initialize to recreate them.
+      if (expectedPages > 0 && aliveCount < expectedPages) {
+        await this.initialize();
+        return;
+      }
+
       const alarms = await chrome.alarms.getAll();
       const hasRotate = alarms.some(
         (a) => a.name === RotationService.ALARM_ROTATE
@@ -189,15 +209,26 @@ export class RotationService {
               if (this.isRotating) await this.stopRotation();
               await startRotation(remoteConfig);
             } else if (!this.isRotating) {
-              // No remote config yet — ensure state reflects that we are idle
-              await this.setRotationState(false);
+              // Remote fetch failed or unchanged — fall back to last saved config
+              if (loadedConfig?.pages?.length) {
+                await startRotation(loadedConfig);
+              } else {
+                await this.setRotationState(false);
+              }
             }
           } catch (error) {
             console.error(
               '[rotator] Failed to load remote configuration:',
               error
             );
-            if (!this.isRotating) await this.setRotationState(false);
+            // Fall back to last saved config if present
+            if (!this.isRotating) {
+              if (loadedConfig?.pages?.length) {
+                await startRotation(loadedConfig);
+              } else {
+                await this.setRotationState(false);
+              }
+            }
           }
         };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Tabs Rotator / Slideshow",
   "short_name": "Tabs Rotator",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Rotates through a set of URLs at specified intervals. Preloads pages in the background and automatically switches between tabs.",
   "permissions": ["tabs", "storage", "activeTab", "webNavigation", "alarms"],
   "host_permissions": ["*://*/*"],

--- a/windows-autostart.md
+++ b/windows-autostart.md
@@ -1,0 +1,79 @@
+# Windows Autostart (Chrome) — Windows 10/11
+
+Start Google Chrome automatically after sign‑in and keep it in the foreground.
+
+Chrome flags used
+
+- `--no-first-run` — Skips first‑run dialogs and the welcome page.
+- `--disable-session-crashed-bubble` — Suppresses the "Chrome didn’t shut down correctly" restore prompt.
+
+(Fullscreen and displayed content are handled by the **Tabs Rotator / Slideshow** extension.)
+
+---
+
+## 1) Save the PowerShell launcher
+
+Create folder `C:\Scripts` and save as `C:\Scripts\Launch-Chrome-Focus.ps1`:
+
+```powershell
+# Launch-Chrome-Focus.ps1 (minimal)
+# Starts Chrome with two flags and brings it to the foreground.
+
+$ChromePath = 'C:\Program Files\Google\Chrome\Application\chrome.exe'
+if (-not (Test-Path $ChromePath)) { Write-Error "Chrome not found at $ChromePath"; exit 1 }
+
+$ArgList = @('--no-first-run','--disable-session-crashed-bubble')
+$proc = Start-Process -FilePath $ChromePath -ArgumentList ($ArgList -join ' ') -PassThru
+
+# Wait up to 20s for a Chrome window
+$deadline = (Get-Date).AddSeconds(20)
+while ((Get-Date) -lt $deadline -and $proc -and -not $proc.HasExited -and $proc.MainWindowHandle -eq 0) {
+  Start-Sleep -Milliseconds 200
+  $proc.Refresh()
+}
+
+# Bring to foreground
+$wshell = New-Object -ComObject WScript.Shell
+try { if ($proc -and -not $proc.HasExited) { $null = $wshell.AppActivate($proc.Id) } } catch {}
+
+Add-Type @"
+using System; using System.Runtime.InteropServices;
+public static class Win32 {
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+}
+"@
+
+if ($proc -and -not $proc.HasExited -and $proc.MainWindowHandle -ne 0) {
+  [Win32]::ShowWindowAsync($proc.MainWindowHandle, 9) | Out-Null  # SW_RESTORE
+  [Win32]::SetForegroundWindow($proc.MainWindowHandle) | Out-Null
+}
+
+# Re-assert focus a few times in case other apps steal it
+1..3 | ForEach-Object {
+  Start-Sleep -Seconds 2
+  try { if ($proc -and -not $proc.HasExited) { $null = $wshell.AppActivate($proc.Id) } } catch {}
+}
+```
+
+---
+
+## 2) Task Scheduler
+
+1. Open **Task Scheduler** → Create Task… (not *Create Basic Task*).
+2. **General** tab:
+   - Name: `Chrome AutoStart`
+   - Run only when user is logged on ✔️
+   - Run with highest privileges: **leave unchecked** (not required to launch Chrome; can introduce UAC/drag‑and‑drop quirks).
+   - Configure for: *Windows 11* (or *Windows 10*)
+3. **Triggers** tab → New…
+   - Begin the task: *At log on*
+   - Delay task for: *30 seconds*
+4. **Actions** tab → New…
+   - Action: *Start a program*
+   - Program/script: `powershell.exe`
+   - Add arguments (optional): `-NoProfile -ExecutionPolicy Bypass -File "C:\Scripts\Launch-Chrome-Focus.ps1"`
+5. **Settings** tab:
+   - If the task is already running, then the following rule applies: *Do not start a new instance*
+   - Run task as soon as possible after a scheduled start is missed ✔️
+6. Click **OK**, then sign out / reboot to test.


### PR DESCRIPTION
This pull request updates the Chrome Tabs Rotator extension to version 1.3.0, focusing on improving reliability after browser or computer restarts, enhancing documentation for Windows autostart, and providing clearer changelog visibility. The most important changes are grouped below:

### Reliability Improvements

* Fixed tab rotation so that it correctly resumes after a browser or computer restart by checking for missing tabs and reinitializing if needed in `rotation.service.ts`.
* Improved fallback logic: if remote configuration fails or is unchanged, the extension now reliably falls back to the last saved configuration.

### Documentation Enhancements

* Added a dedicated section and guide for Windows autostart in `README.md` and created `windows-autostart.md` with step-by-step instructions for automatic Chrome startup. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82-R86) [[2]](diffhunk://#diff-dad2cdaed9d3d77132f73a07a545f6d29b4eecdff19c92e32bd21ed97db0fc46R1-R79)
* Updated `description.txt` to reference the new Windows autostart guide and clarified changelog and privacy information.

### Changelog Visibility

* Added a "Changelog" section to `README.md` and linked to the full changelog file for easier access.
* Updated `CHANGELOG.md` with details for version 1.3, highlighting the rotation fix after restart.

### Version Bump

* Updated extension version to 1.3 in both `package.json` and `manifest.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-6bc2c0b5164076a1b57b067398be19a40d2b8efa3428b03504562ea88593866cL5-R5)

Fixes #1